### PR TITLE
Allow forwarding arbitrary MCP flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Env/flags
 - --no-sandbox: launch Chrome with --no-sandbox (dev only)
 - --chrome-bin <path>: explicit Chrome executable
 - --mcp-cmd <cmd>: override MCP launcher (default: npx)
-- --mcp-args "...": extra args (default pulls chrome-devtools-mcp via npx)
+- --mcp-args "...": extra args (default pulls chrome-devtools-mcp via npx). Native
+  chrome-devtools-mcp flags like `--isolated` / `--connect-url=...` pass through
+  unchanged, so you can opt out of the auto-launched Chrome when needed. You can
+  also tack on any additional chrome-devtools-mcp flags after the bridge options
+  (e.g., ``chrome-devtools-mcp-bridge host -- --isolated --foo=bar``) and they'll
+  be forwarded verbatim.
 
 WSL ↔ Windows
 If host/port route correctly between WSL and Windows, this can bridge WSL MCP to Windows Chrome. On modern WSL2, Windows loopback is mirrored so localhost often works; otherwise, use the Windows host IP (ipconfig.exe) and allow the port in the Windows firewall.

--- a/src/server.js
+++ b/src/server.js
@@ -38,6 +38,7 @@ function parse(argv) {
     chromeBin: args.chromeBin || d.chromeBin,
     mcpCmd: args.mcpCmd || d.mcpCmd,
     mcpArgs: (args.mcpArgs ? args.mcpArgs.split(" ") : d.mcpArgs),
+    forwardArgs: args._ || [],
     daemon: !!args.daemon,
     logFile: args.logFile || process.env.MCP_BRIDGE_LOG || "",
     pidFile: args.pidFile || process.env.MCP_BRIDGE_PID || ""
@@ -77,6 +78,11 @@ function resolveChrome(chromeBin) {
   return "google-chrome";
 }
 
+function hasFlag(args, name) {
+  const prefix = `${name}=`;
+  return args.some((arg) => arg === name || arg.startsWith(prefix));
+}
+
 async function launchChrome(host, noSandbox, chromeBin) {
   const port = await findFreePort(host);
   const userDataDir = mkTempDir("chrome-mcp-bridge-ud-");
@@ -104,6 +110,10 @@ async function launchChrome(host, noSandbox, chromeBin) {
 module.exports = function main(argv) {
   const cfg = parse(argv || process.argv);
 
+  const passthrough = [...cfg.mcpArgs, ...cfg.forwardArgs];
+  const userProvidedTarget =
+    hasFlag(passthrough, "--connect-url") || hasFlag(passthrough, "--isolated");
+
   // Optional daemonize
   if (cfg.daemon && process.env.MCP_BRIDGE_DAEMON_CHILD !== "1") {
     try {
@@ -118,6 +128,7 @@ module.exports = function main(argv) {
       if (cfg.chromeBin) childArgv.push("--chromeBin", cfg.chromeBin);
       if (cfg.mcpCmd) childArgv.push("--mcpCmd", cfg.mcpCmd);
       if (cfg.mcpArgs && cfg.mcpArgs.length) childArgv.push("--mcpArgs", cfg.mcpArgs.join(" "));
+      if (cfg.forwardArgs && cfg.forwardArgs.length) childArgv.push(...cfg.forwardArgs);
 
       const outFd = cfg.logFile ? fs.openSync(cfg.logFile, "a") : "ignore";
       const errFd = outFd;
@@ -139,21 +150,24 @@ module.exports = function main(argv) {
   }
 
   const server = net.createServer(async (socket) => {
+    const childArgs = [...cfg.mcpArgs, ...cfg.forwardArgs];
     let cleanupChrome = null;
     let connectUrl = null;
-    try {
-      const { url, cleanup } = await launchChrome(cfg.host, cfg.noSandbox, cfg.chromeBin);
-      connectUrl = url;
-      cleanupChrome = cleanup;
-    } catch (e) {
-      console.error("[mcp-bridge] Failed to launch Chrome:", e && e.message ? e.message : e);
-    }
 
-    const childArgs = [...cfg.mcpArgs];
-    if (connectUrl) {
-      childArgs.push("--connect-url", connectUrl);
-    } else {
-      childArgs.push("--isolated");
+    if (!userProvidedTarget) {
+      try {
+        const { url, cleanup } = await launchChrome(cfg.host, cfg.noSandbox, cfg.chromeBin);
+        connectUrl = url;
+        cleanupChrome = cleanup;
+      } catch (e) {
+        console.error("[mcp-bridge] Failed to launch Chrome:", e && e.message ? e.message : e);
+      }
+
+      if (connectUrl) {
+        childArgs.push("--connect-url", connectUrl);
+      } else {
+        childArgs.push("--isolated");
+      }
     }
 
     const child = spawn(cfg.mcpCmd, childArgs, { stdio: ["pipe", "pipe", "inherit"] });

--- a/src/util.js
+++ b/src/util.js
@@ -9,11 +9,25 @@ function parseArgv(argv, spec) {
   spec.forEach((s) => (s.alias || []).forEach((a) => aliasTo.set(a, s.name)));
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
+    if (a === "--") {
+      out._.push(...argv.slice(i + 1));
+      break;
+    }
     if (a.startsWith("--")) {
       const key = a.slice(2);
       const name = map.has(key) ? key : aliasTo.get(key);
       const def = name ? map.get(name) : null;
-      if (!def) continue;
+      if (!def) {
+        out._.push(a);
+        if (!a.includes("=")) {
+          const v = argv[i + 1];
+          if (v != null && !v.startsWith("-")) {
+            out._.push(v);
+            i++;
+          }
+        }
+        continue;
+      }
       if (def.type === "boolean") {
         out[name] = true;
       } else {
@@ -26,7 +40,15 @@ function parseArgv(argv, spec) {
       const key = a.slice(1);
       const name = aliasTo.get(key);
       const def = name ? map.get(name) : null;
-      if (!def) continue;
+      if (!def) {
+        out._.push(a);
+        const v = argv[i + 1];
+        if (v != null && !v.startsWith("-")) {
+          out._.push(v);
+          i++;
+        }
+        continue;
+      }
       if (def.type === "boolean") {
         out[name] = true;
       } else {


### PR DESCRIPTION
## Summary
- capture unrecognized CLI options and pass them through to chrome-devtools-mcp
- forward passthrough flags in daemon mode and when spawning MCP so native options like --isolated work
- document how to append arbitrary MCP flags to the bridge command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd466d2d5c832aa021ab5bbd4af25e